### PR TITLE
fix: improve RTL support of horizontal scrollviews

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
@@ -14,7 +14,7 @@ public class ReactHorizontalScrollContainerView extends ViewGroup {
     void onLayout();
   }
 
-  private int mLayoutDirection;;
+  private int mLayoutDirection;
   private int mLastWidth = 0;
   private Listener rtlListener = null;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -11,6 +11,7 @@ import android.graphics.Color;
 import android.util.DisplayMetrics;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
@@ -135,11 +136,39 @@ public class ReactHorizontalScrollViewManager
 
   @Override
   public void scrollTo(
-      ReactHorizontalScrollView scrollView, ReactScrollViewCommandHelper.ScrollToCommandData data) {
+          final ReactHorizontalScrollView scrollView, final ReactScrollViewCommandHelper.ScrollToCommandData data) {
+    boolean isRTL = I18nUtil.getInstance().isRTL(scrollView.getContext());
+
+    int destX = data.mDestX;
+
+    if (isRTL && scrollView.getChildAt(0) instanceof ReactHorizontalScrollContainerView) {
+      final ReactHorizontalScrollContainerView child = (ReactHorizontalScrollContainerView) scrollView.getChildAt(0);
+
+      // correct the x offset destination, as on android the scrollOffset is not adjusted to RTL
+      // i.e. the right-most part of the view will be a positive index and the left-most negative
+      destX = child.getWidth() - scrollView.getWidth() - destX;
+
+      // If the scrollContainerView is in RTL mode, fix the current scroll position in
+      // reaction to layout changes - need to listen for layout change events (e.g. because of
+      // fetching new data) and update the scroll position accordingly as soon as it's available
+      child.setListener(new ReactHorizontalScrollContainerView.Listener() {
+        @Override
+        public void onLayout() {
+          int destX = child.getWidth() - child.getLastWidth() + scrollView.getScrollX();
+
+          if (data.mAnimated) {
+              scrollView.smoothScrollTo(destX, data.mDestY);
+          } else {
+              scrollView.scrollTo(destX, data.mDestY);
+          }
+        }
+      });
+    }
+
     if (data.mAnimated) {
-      scrollView.smoothScrollTo(data.mDestX, data.mDestY);
+      scrollView.smoothScrollTo(destX, data.mDestY);
     } else {
-      scrollView.scrollTo(data.mDestX, data.mDestY);
+      scrollView.scrollTo(destX, data.mDestY);
     }
   }
 


### PR DESCRIPTION
## Summary
Horizontal Scrollviews were being handled incorrectly in RTL mode on Android. In particular: 

1. ScrollTo methods were not working as intended. Providing an xOffset actually scrolled, but on the wrong side.
2. Fetching additional data in the ScrollView caused the view to scroll to do a different location, leading to unintended consequences (e.g. scrolls happened if the size of the container changed, even without the user scrolling).

This PR solves both problems by improving the way X offsets are calculated by the Horizontal ScrollView Component.

## Changelog
[Android] [Fixed] - Improve RTL support of Horizontal ScrollViews on Android.

## Test Plan
TBD